### PR TITLE
Fix shift prompt leaking when shifting rival's unforged card

### DIFF
--- a/src/clj/game/core/shifting.clj
+++ b/src/clj/game/core/shifting.clj
@@ -23,7 +23,7 @@
   ([state side eid source-card card-to-shift {:keys [cost other-side? no-wait-prompt?] :as args}]
    (show-shift-prompt
      state side eid source-card (adjacent-zones card-to-shift)
-     (str "Shift " (:title card-to-shift) " where?")
+     (str "Shift " (hubworld-card-str state card-to-shift) " where?")
      {:cost cost
       :msg (msg (let [server (:server context)
                       slot (:slot context)


### PR DESCRIPTION
Currently Canal Network leaks the card you are shifting.

<img width="416" alt="image" src="https://github.com/user-attachments/assets/2b9fa1ef-036a-466f-b946-13cd1ba02959" />
