### PR TITLE
Fix Shardwinner getting +4 presence on Commons

### DIFF
--- a/src/clj/game/cards/sources.clj
+++ b/src/clj/game/cards/sources.clj
@@ -54,9 +54,8 @@
 (defcard "Shardwinner"
   (collect
     {:shards 1}
-    {:presence-bonus (req (if (and (same-card? card target)
-                                   (installed? card)
-                                   (in-commons-path? (get-card state card)))
+    {:presence-bonus (req (if (and (installed? card)
+                                   (in-commons-path? card))
                             4 0))
      :static-abilities [{:type :collect-shards-bonus
                          :req (req (and (same-card? card target)


### PR DESCRIPTION
<img width="325" alt="image" src="https://github.com/user-attachments/assets/f576e5f0-b33e-4421-82e0-dde6068c8d21" />
