### PR TITLE
display the affiliation limits in the deckbuilder

### DIFF
--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -57,6 +57,12 @@
   (let [identity-faction (get-in deck [:identity :faction])]
     (line-base-cost identity-faction line)))
 
+(defn affiliation-map
+  [deck]
+  (let [agents (filter #(= (->> % :card :type) "Agent") (:cards deck))
+        affiliations (sort (map #(->> % :card faction-label keyword) agents))]
+    (frequencies affiliations)))
+
 (defn influence-map
   "Returns a map of faction keywords to influence values from the faction's cards."
   [deck]

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -425,7 +425,7 @@
 (defn deck-influence-html
   "Returns hiccup-ready vector with dots colored appropriately to deck's influence."
   [deck]
-  (dots-html influence-dot (validator/influence-map deck)))
+  (dots-html influence-dot (validator/affiliation-map deck)))
 
 (defn distinct-by [f coll]
   (letfn [(step [xs seen]
@@ -746,6 +746,8 @@
         [:div count (str " " (tr [:deck-builder.cards "cards"]))
          (when-not (<= min-count count max-count)
            [:span.invalid (str " (" (tr [:deck-builder.expected "expected:"]) " " min-count ")")])])
+      [:div (str (tr [:deck-builder.affiliation "Affiliation"]) ": ")
+       (deck-influence-html deck)]
       ;; TODO - figure out how the inf works once enough info is out
       ;; (let [inf (validator/influence-count deck)
       ;;       id-limit (validator/id-inf-limit id)]

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -402,19 +402,17 @@
 (defn card-influence-html
   "Returns hiccup-ready vector with dots for influence as well as rotated / restricted / banned symbols"
   [format card qty in-faction allied?]
-  (let [influence (* (:factioncost card) qty)
+  (let [influence (:factioncost card 0)
         card-status (format-status format card)
         banned (:banned card-status)
         restricted (:restricted card-status)
         rotated (:rotated card-status)
         points (:points card-status)]
     [:span " "
-     (when (and (not banned) (not in-faction))
+     (when (not banned)
        [:span.influence {:key "influence"
                          :class (utils/faction-label card)}
-        (if allied?
-          (alliance-dots influence)
-          (influence-dots influence))])
+        (influence-dots influence)])
      (if banned
        banned-span
        [:span {:key "restricted"}

--- a/src/css/factions.styl
+++ b/src/css/factions.styl
@@ -45,6 +45,19 @@
 .influence.neutral
     color: white-solid
 
+// hubworld: aidalon
+.influence.old-aidalon
+    color: green-core
+
+.influence.omniworks
+    color: orange-core
+
+.influence.the-remnants
+    color: purple-core
+
+.influence.the-collective
+    color: blue-core
+
 // Corps
 .influence.haas-bioroid
     color: purple-core


### PR DESCRIPTION
Display the available affiliation in the deckbuilder.

![influence-a](https://github.com/user-attachments/assets/a2b604bc-080d-45e5-80f8-75849e1acd28)

~~I'm not scraping affiliation requirements yet, so I can't display those.~~
Now I am, so I can.

![influence](https://github.com/user-attachments/assets/771a0ce2-6246-4a2c-96bb-4163f1db6448)