### PR TITLE
Update rules text for a few cards

### DIFF
--- a/src/clj/game/cards/agents.clj
+++ b/src/clj/game/cards/agents.clj
@@ -24,23 +24,33 @@
 (defcard "Auntie Ruth: Proprietor of the Hidden Tea House"
   (collect
     {:shards 1}
-    {:reaction [{:reaction :forge
-                 :type :ability
-                 :max-uses 1
-                 :req (req (same-card? card (:card context)))
-                 :ability {:prompt "Choose a player"
-                           :waiting-prompt true
-                           :choices {:req (req (or (same-card? target (get-in @state [:corp :identity]))
-                                                   (same-card? target (get-in @state [:runner :identity]))))
-                                     :all true}
-                           :msg (msg (let [target-side (keyword (str/lower-case (:side target)))]
-                                       (str
-                                         (when-not (= target-side side)
-                                           (str "force " (other-player-name state side) " to "))
-                                         "draw 3 cards")))
-                           :async true
-                           :effect (req (let [target-side (keyword (str/lower-case (:side target)))]
-                                          (draw state target-side eid 3)))}}]
+    ;; {:reaction [{:reaction :forge
+    ;;              :type :ability
+    ;;              :max-uses 1
+    ;;              :req (req (same-card? card (:card context)))
+    ;;              :ability {:prompt "Choose a player"
+    ;;                        :waiting-prompt true
+    ;;                        :choices {:req (req (or (same-card? target (get-in @state [:corp :identity]))
+    ;;                                                (same-card? target (get-in @state [:runner :identity]))))
+    ;;                                  :all true}
+    ;;                        :msg (msg (let [target-side (keyword (str/lower-case (:side target)))]
+    ;;                                    (str
+    ;;                                      (when-not (= target-side side)
+    ;;                                        (str "force " (other-player-name state side) " to "))
+    ;;                                      "draw 3 cards")))
+    ;;                        :async true
+    ;;                        :effect (req (let [target-side (keyword (str/lower-case (:side target)))]
+    ;;                                       (draw state target-side eid 3)))}}]
+    {:abilities [{:cost [(->c :exhaust-self)]
+                  :label "Draw a card"
+                  :async true
+                  :msg "draw a card"
+                  :effect (req (draw state side eid 1))}
+                 {:cost [(->c :exhaust-self)]
+                  :label "Your opponent draws a card"
+                  :async true
+                  :msg (msg "force " (other-player-name state side) " to draw a card")
+                  :effect (req (draw state opponent eid 1))}]
      :cipher [(->c :lose-click 1)]}))
 
 (defcard "Big Varna Gorvis: Friends in Every District"
@@ -51,7 +61,7 @@
                             :waiting-prompt true
                             :prompt "Archive 1 card from your opponent's council?"
                             :req (req (and (> (count (get-in @state [side :hand]))
-                                              (count (get-in @state [(other-side side) :hand])))
+                                              (count (get-in @state [opponent :hand])))
                                            (seq (get-in @state [(other-side side) :hand]))))
                             :yes-ability {:msg (msg "archive 1 card at random from " (other-player-name state side) "'s Council")
                                           :async true

--- a/src/clj/game/cards/agents.clj
+++ b/src/clj/game/cards/agents.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [game.core.board :refer [hubworld-all-installed]]
-   [game.core.card :refer [in-hand? installed? agent? source? obstacle? rezzed? seeker?]]
+   [game.core.card :refer [in-hand? in-rfg? installed? agent? source? obstacle? rezzed? seeker?]]
    [game.core.def-helpers :refer [collect]]
    [game.core.drawing :refer [draw]]
    [game.core.def-helpers :refer [defcard stage-n-cards shift-self-abi]]
@@ -10,7 +10,7 @@
    [game.core.eid :refer [effect-completed]]
    [game.core.exhausting :refer [unexhaust exhaust]]
    [game.core.gaining :refer [gain-credits]]
-   [game.core.moving :refer [mill archive]]
+   [game.core.moving :refer [mill move archive]]
    [game.core.payment :refer [->c can-pay?]]
    [game.core.presence :refer [update-card-presence]]
    [game.core.rezzing :refer [derez]]
@@ -136,7 +136,15 @@
 (defcard "Doctor Twilight: Dream Surgeon"
   (collect
     {:cards 1}
-    {:abilities [{:cost [(->c :exhaust-self) (->c :exile-from-archives 1)]
+    {:discover-abilities [{:label "Move 1 card from Exile to Archives"
+                           :req (req (seq (get-in @state [side :rfg])))
+                           :show-exile true
+                           :prompt "Add 1 card from your Exile to your Archives"
+                           :choices {:req (req (and (my-card? target)
+                                                    (in-rfg? target)))}
+                           :msg (msg "move " (:title target) " from [their] Exile to [their] Archives")
+                           :effect (req (move state side target :discard))}]
+     :abilities [{:cost [(->c :exhaust-self) (->c :exile-from-archives 1)]
                   :label "Gain 3 [Credits]"
                   :msg "gain 3 [Credits]"
                   :async true

--- a/src/clj/game/cards/obstacles.clj
+++ b/src/clj/game/cards/obstacles.clj
@@ -52,30 +52,30 @@
 
 (defcard "Canal Network"
   {:confront-abilities [{:async true
-                         :prompt "Shift an unforged card on your opponent's grid"
+                         :prompt "Shift an unforged card?"
                          :waiting-prompt true
                          :req (req (seq (filter #(and (installed? %)
-                                                  (not= side (to-keyword (:side %)))
-                                                  (not= "Seeker" (:type %))
-                                                  (not (rezzed? %)))
-                                                (hubworld-all-installed state (other-side side)))))
+                                                      (not= "Seeker" (:type %))
+                                                      (not (rezzed? %)))
+                                                (concat (hubworld-all-installed state opponent)
+                                                        (hubworld-all-installed state side)))))
                          :choices {:req (req (and (installed? target)
-                                                  (not= side (to-keyword (:side target)))
                                                   (not= "Seeker" (:type target))
                                                   (not (rezzed? target))))}
-                         :effect (req (shift-a-card state side eid card target {:other-side? true :no-wait-prompt? true}))}]
+                         :effect (req (shift-a-card state side eid card target {:other-side? (not (my-card? target)) :no-wait-prompt? true}))}]
    :discover-abilities [{:async true
-                         :label "Shift a card on your opponent's grid"
-                         :prompt "Exhaust your Seeker: Shift a card on your opponent's grid"
+                         :label "Shift a card"
+                         :prompt "Shift a card?"
                          :waiting-prompt true
-                         :req (req (and (can-pay? state side eid card nil [(->c :exhaust-seeker)])
+                         :req (req (and (installed? card)
                                         (seq (filter #(and (installed? %)
-                                                           (not (seeker? %)))
-                                                     (hubworld-all-installed state (other-side side))))))
+                                                           (not= "Seeker" (:type %)))
+                                                     (concat (hubworld-all-installed state opponent)
+                                                             (hubworld-all-installed state side))))))
                          :choices {:req (req (and (installed? target)
-                                                  (not= side (to-keyword (:side target)))
                                                   (not= "Seeker" (:type target))))}
-                         :effect (req (shift-a-card state side eid card target {:other-side? true :cost [(->c :exhaust-seeker)] :no-wait-prompt? true}))}]})
+                         :effect (req
+                                   (shift-a-card state side eid card target {:other-side? (not (my-card? target)) :no-wait-prompt? true}))}]})
 
 (defcard "Emperor Drejj"
   {:reaction [{:reaction :forge

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -140,7 +140,7 @@
   (when-let [card (get-card state card)]
     (let [context (assoc context :card card)
           card-to-stage card
-          rush-abi {:msg (msg (println context) "rush itself to the " (name (:slot context)) " row of [their] " (string/capitalize (name (:server context))))
+          rush-abi {:msg (msg "rush itself to the " (name (:slot context)) " row of [their] " (string/capitalize (name (:server context))))
                     :async true
                     :cost [(->c :credit (rez-cost state side card-to-stage nil))]
                     :effect (req (let [c (:card context) server (:server context) slot (:slot context)]

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -237,6 +237,7 @@
    :card
    :prompt-type
    :show-discard
+   :show-exile
    :selectable
    ;; hubworld stuff
    :target-paths

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -562,8 +562,8 @@
     (when (and (pred? a)
                (pred? b)
                (same-side? a b))
-      (let [a (get-card state a)
-            b (get-card state b)
+      (let [a (dissoc (get-card state a) :seen)
+            b (dissoc (get-card state b) :seen)
             a-new (assoc a :zone (:zone b))
             b-new (assoc b :zone (:zone a))]
         (swap! state assoc-in (cons side (:zone a)) [b-new])
@@ -585,7 +585,7 @@
   [state side a server slot]
   (let [pred? (every-pred installed?)]
     (when (pred? a)
-      (let [a (get-card state a)
+      (let [a (dissoc (get-card state a) :seen)
             a-new (assoc a :zone [:paths server slot])]
         (swap! state assoc-in [side :paths server slot] [a-new])
         (swap! state assoc-in (concat [side] (:zone a)) [])

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -34,7 +34,7 @@
   ([state side card message choices f] (show-prompt state side (make-eid state) card message choices f nil))
   ([state side card message choices f args] (show-prompt state side (make-eid state) card message choices f args))
   ([state side eid card message choices f
-    {:keys [waiting-prompt prompt-type show-discard cancel-effect end-effect targets selectable]}]
+    {:keys [waiting-prompt prompt-type show-discard show-exile cancel-effect end-effect targets selectable]}]
    (let [prompt (if (string? message) message (message state side eid card targets))
          choices (choice-parser choices)
          selectable (update-selectable selectable choices)
@@ -47,6 +47,7 @@
                   :selectable selectable
                   :prompt-type (or prompt-type :other)
                   :show-discard show-discard
+                  :show-exile show-exile
                   :cancel-effect cancel-effect
                   :end-effect end-effect}]
      (when (or (#{:waiting :run} prompt-type)
@@ -322,6 +323,7 @@
                     (-> args
                         (assoc :prompt-type :select
                                :selectable selectable-cards
+                               :show-exile (:show-exile ability)
                                :show-discard (:show-discard ability))
                         (wrap-function :cancel-effect)))))))
 

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -1,5 +1,6 @@
 (ns game.macros
-  (:require [clojure.tools.analyzer.jvm :as a.j]
+  (:require [clojure.string :as str]
+            [clojure.tools.analyzer.jvm :as a.j]
             [clojure.tools.analyzer.ast :as ast]))
 
 (def forms
@@ -36,6 +37,7 @@
       runnable-servers (game.core.servers/zones->sorted-names
                          (game.core.runs/get-runnable-zones state side eid card nil))
       opponent (if (= side :corp) :runner :corp)
+      my-card? (fn [c] (= (keyword (str/lower-case (:side c))) side))
       hq-runnable (some #{:hq} (game.core.runs/get-runnable-zones state))
       rd-runnable (some #{:rd} (game.core.runs/get-runnable-zones state))
       archives-runnable (some #{:archives} (game.core.runs/get-runnable-zones state))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -35,6 +35,7 @@
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (game.core.servers/zones->sorted-names
                          (game.core.runs/get-runnable-zones state side eid card nil))
+      opponent (if (= side :corp) :runner :corp)
       hq-runnable (some #{:hq} (game.core.runs/get-runnable-zones state))
       rd-runnable (some #{:rd} (game.core.runs/get-runnable-zones state))
       archives-runnable (some #{:archives} (game.core.runs/get-runnable-zones state))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -1,6 +1,5 @@
 (ns game.macros
-  (:require [clojure.string :as str]
-            [clojure.tools.analyzer.jvm :as a.j]
+  (:require [clojure.tools.analyzer.jvm :as a.j]
             [clojure.tools.analyzer.ast :as ast]))
 
 (def forms
@@ -37,7 +36,7 @@
       runnable-servers (game.core.servers/zones->sorted-names
                          (game.core.runs/get-runnable-zones state side eid card nil))
       opponent (if (= side :corp) :runner :corp)
-      my-card? (fn [c] (= (keyword (str/lower-case (:side c))) side))
+      my-card? (fn [c] (= (keyword (clojure.string/lower-case (:side c))) side))
       hq-runnable (some #{:hq} (game.core.runs/get-runnable-zones state))
       rd-runnable (some #{:rd} (game.core.runs/get-runnable-zones state))
       archives-runnable (some #{:archives} (game.core.runs/get-runnable-zones state))

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -42,21 +42,21 @@
        (or (= #{a b} #{:inner :middle}) (= #{a b} #{:middle :outer}))))
 
 (defn adjacent-zones
-  [card]
-  (let [[_ server slot] (:zone card)
-        neighbors  (for [sr [:archives :council :commons]
-                         sl [:inner :middle :outer]
-                         :when (and (or (and (adjacent-server sr server)
-                                             (= sl slot))
-                                        (and (adjacent-slot sl slot)
-                                             (= sr server))))]
-                     {:slot sl
-                      :server sr})]
-    (reduce
-      (fn [acc {:keys [server slot]}]
-        (update acc server #(assoc (or % {}) slot true)))
-      {}
-      neighbors)))
+  ([card] (let [[_ server slot] (:zone card)] (adjacent-zones server slot)))
+  ([server slot]
+   (let [neighbors  (for [sr [:archives :council :commons]
+                          sl [:inner :middle :outer]
+                          :when (and (or (and (adjacent-server sr server)
+                                              (= sl slot))
+                                         (and (adjacent-slot sl slot)
+                                              (= sr server))))]
+                      {:slot sl
+                       :server sr})]
+     (reduce
+       (fn [acc {:keys [server slot]}]
+         (update acc server #(assoc (or % {}) slot true)))
+       {}
+       neighbors))))
 
 (defn adjacent?
   [c1 {:keys [zone] :as c2}]

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -2003,6 +2003,7 @@
 (defn button-pane [{:keys [side prompt-state]}]
   (let [autocomp (r/track (fn [] (get-in @prompt-state [:choices :autocomplete])))
         show-discard? (r/track (fn [] (get-in @prompt-state [:show-discard])))
+        show-exile? (r/track (fn [] (get-in @prompt-state [:show-exile])))
         prompt-type (r/track (fn [] (get-in @prompt-state [:prompt-type])))
         opened-by-system (r/atom false)]
     (r/create-class
@@ -2014,7 +2015,10 @@
            (-> "#card-title" js/$ (.autocomplete (clj->js {"source" @autocomp}))))
          (cond @show-discard? (do (-> ".me .discard-container .popup" js/$ .fadeIn)
                                   (reset! opened-by-system true))
+               @show-exile? (do (-> ".me .exile-container .popup" js/$ .fadeIn)
+                                  (reset! opened-by-system true))
                @opened-by-system (do (-> ".me .discard-container .popup" js/$ .fadeOut)
+                                     (-> ".me .exile-container .popup" js/$ .fadeOut)
                                      (reset! opened-by-system false)))
          (if (= "select" @prompt-type)
            (set! (.-cursor (.-style (.-body js/document))) "url('/img/gold_crosshair.png') 12 12, crosshair")

--- a/test/clj/game/cards/agents_tests.clj
+++ b/test/clj/game/cards/agents_tests.clj
@@ -87,6 +87,15 @@
   (collects? {:name "Doctor Twilight: Dream Surgeon"
               :cards 1}))
 
+(deftest doctor-twilight-discover-ability
+  (do-game
+    (new-game {:runner {:hand ["Doctor Twilight: Dream Surgeon"] :exile ["Shardwinner"]}})
+    (click-credit state :corp)
+    (click-credit state :runner)
+    (delve-empty-server state :corp :council {:give-heat? true})
+    (click-card state :runner "Shardwinner")
+    (is-discard? state :runner ["Shardwinner"])))
+
 (deftest gargala-larga-imperator-of-growth-unexhaust-seeker
   (do-game
     (new-game {:corp {:hand ["Gargala Larga: Imperator of Growth"]}})

--- a/test/clj/game/cards/agents_tests.clj
+++ b/test/clj/game/cards/agents_tests.clj
@@ -134,19 +134,33 @@
           (forge state :corp (pick-card state :corp :council :outer)))
         "1c discount")))
 
-(deftest kryzar-free-stage
-  (do-game
-    (new-game {:corp {:hand ["Kryzar the Rat: Navigator of the Cortex Maze"
-                             "Eye Enforcers"]}})
-    (play-from-hand state :corp "Kryzar the Rat: Navigator of the Cortex Maze" :council :inner)
-    (click-credit state :runner)
-    (forge state :corp (pick-card state :corp :council :inner))
-    (delve-server state :corp :council)
-    (delve-continue-to-approach state :corp)
-    (click-prompts state :corp "Kryzar the Rat: Navigator of the Cortex Maze" "Yes" "Eye Enforcers")
-    (stage-select state :corp :council :outer)
-    (is (exhausted? (pick-card state :corp :council :inner)) "Exhausted kryzar")
-    (is (= "Eye Enforcers" (:title (pick-card state :corp :council :outer))) "Staged EE")))
+;; (deftest kryzar-free-stage
+;;   (do-game
+;;     (new-game {:corp {:hand ["Kryzar the Rat: Navigator of the Cortex Maze"
+;;                              "Eye Enforcers"]}})
+;;     (play-from-hand state :corp "Kryzar the Rat: Navigator of the Cortex Maze" :council :inner)
+;;     (click-credit state :runner)
+;;     (forge state :corp (pick-card state :corp :council :inner))
+;;     (delve-server state :corp :council)
+;;     (delve-continue-to-approach state :corp)
+;;     (click-prompts state :corp "Kryzar the Rat: Navigator of the Cortex Maze" "Yes" "Eye Enforcers")
+;;     (stage-select state :corp :council :outer)
+;;     (is (exhausted? (pick-card state :corp :council :inner)) "Exhausted kryzar")
+;;     (is (= "Eye Enforcers" (:title (pick-card state :corp :council :outer))) "Staged EE")))
+
+(deftest kryzar-bypass-works
+  (doseq [[serv slot] [[:council :middle] [:commons :outer] [:archives :outer]]]
+    (do-game
+      (new-game {:corp {:hand ["Kryzar the Rat: Navigator of the Cortex Maze" "Shardwinner"]}})
+      (click-credit state :corp)
+      (click-credit state :runner)
+      (delve-server state :corp :council)
+      (rush-from-hand state :corp "Kryzar the Rat: Navigator of the Cortex Maze" :council :inner)
+      (card-ability state :corp (pick-card state :corp :council :inner) 1)
+      (stage-select state :corp serv slot)
+      (click-card state :corp "Shardwinner")
+      (is (= serv (:server (:delve @state))) "Correct server")
+      (is (= slot (:position (:delve @state))) "Correct slot"))))
 
 (deftest kryzar-the-rat-collects
   (collects? {:name "Kryzar the Rat: Navigator of the Cortex Maze"

--- a/test/clj/game/cards/agents_tests.clj
+++ b/test/clj/game/cards/agents_tests.clj
@@ -7,24 +7,34 @@
    [game.test-framework :refer :all]
    [game.core.payment :refer [->c]]))
 
-(deftest auntie-ruth-draw-3
-  (doseq [s [:corp :runner]]
+;; (deftest auntie-ruth-draw-3
+;;   (doseq [s [:corp :runner]]
+;;     (do-game
+;;       (new-game {:corp {:hand ["Auntie Ruth: Proprietor of the Hidden Tea House"]
+;;                         :deck [(qty "Fun Run" 4)]}
+;;                  :runner {:hand []
+;;                           :deck [(qty "Fun Run" 10)]}})
+;;       (play-from-hand state :corp "Auntie Ruth: Proprietor of the Hidden Tea House" :council :inner)
+;;       (forge state :corp (pick-card state :corp :council :inner))
+;;       (is (changed? [(count (get-hand state s)) 3]
+;;             (click-prompt state :corp "Auntie Ruth: Proprietor of the Hidden Tea House")
+;;             (click-card state :corp (get-id state s)))
+;;           (str "side: " s " drew 3")))))
+
+(deftest auntie-ruth-force-draw
+  (doseq [[s a] [[:corp 1] [:runner 2]]]
     (do-game
-      (new-game {:corp {:hand ["Auntie Ruth: Proprietor of the Hidden Tea House"]
-                        :deck [(qty "Fun Run" 4)]}
-                 :runner {:hand []
-                          :deck [(qty "Fun Run" 10)]}})
+      (new-game {:corp {:hand ["Auntie Ruth: Proprietor of the Hidden Tea House"] :deck ["Fun Run"]}})
       (play-from-hand state :corp "Auntie Ruth: Proprietor of the Hidden Tea House" :council :inner)
       (forge state :corp (pick-card state :corp :council :inner))
-      (is (changed? [(count (get-hand state s)) 3]
-            (click-prompt state :corp "Auntie Ruth: Proprietor of the Hidden Tea House")
-            (click-card state :corp (get-id state s)))
-          (str "side: " s " drew 3")))))
+      (is (changed? [(count (get-hand state s)) 1]
+            (card-ability state :corp (pick-card state :corp :council :inner) a))
+          "Forced a draw for side"))))
 
 (deftest auntie-ruth-collects
   (collects? {:name "Auntie Ruth: Proprietor of the Hidden Tea House"
-              :credits 1
-              :prompts ["Auntie Ruth: Proprietor of the Hidden Tea House" "Goldie Xin: Junk Collector"]}))
+              ;;:prompts ["Auntie Ruth: Proprietor of the Hidden Tea House" "Goldie Xin: Junk Collector"]
+              :credits 1}))
 
 (deftest auntie-ruth-cipher-lose-one-action
   (do-game


### PR DESCRIPTION
I updated the text for auntie ruth to match her new image.

I also added the `opponent` form, which is the opposite of `side`
and the `my-card [c]` form, which checks if a card is for my (the owner of the ability) side.
Closes #48

I updated the text for doctor twilight so he has his discover ability.

I made waterway canal use the updated text, and made shifting cards during discovery make them facedown again.

Closes #40

I made kryzar the rat use the new text too, and also added the ability to unit test for the rush mechanic.

Closes #52