### PR TITLE
Add /exile command

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -15,7 +15,7 @@
    [game.core.flags :refer [is-scored?]]
    [game.core.identities :refer [disable-identity disable-card enable-card]]
    [game.core.initializing :refer [card-init deactivate make-card]]
-   [game.core.moving :refer [move swap-installed trash]]
+   [game.core.moving :refer [move swap-installed trash exile]]
    [game.core.prompt-state :refer [remove-from-prompt-queue]]
    [game.core.prompts :refer [show-prompt show-stage-prompt show-bluff-prompt]]
    [game.core.props :refer [set-prop]]
@@ -288,6 +288,12 @@
                                              (make-card {:title "/enable-card command"}) nil)
             "/enable-api-access" command-enable-api-access
             "/error"      show-error-toast
+            "/exile"      #(resolve-ability %1 %2
+                                          {:prompt "Choose a card"
+                                           :async true
+                                           :effect (req (exile %1 %2 (make-eid %1) target))
+                                           :choices {:card (fn [t] (same-side? (:side t) %2))}}
+                                          (make-card {:title "/exile command"}) nil)
             "/handsize"   #(change %1 %2 {:key :hand-size
                                           :delta (- (constrain-value value -1000 1000)
                                                     (get-in @%1 [%2 :hand-size :total]))})

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -190,6 +190,9 @@
    {:name "/error"
     :usage "/error"
     :help "Displays an error toast"}
+   {:name "/exile"
+    :usage "/exile"
+    :help "Choose a card to exile (rival will secure if exiling an agent)"}
    {:name "/handsize"
     :has-args :required
     :usage "/handsize n"


### PR DESCRIPTION
Ran into an issue in a game where opponent should have been able to secure an agent during a Council breach but misclicked - and when trying to manually resolve couldn't actually work out how to give them the agent. `/rfg` moves the agent straight into Exile zone which is technically not possible by the rules. So instead just having an explicit command to Exile and fire whatever triggers should happen.