### PR TITLE
a few bugfixes

### DIFF
--- a/src/clj/game/cards/moments.clj
+++ b/src/clj/game/cards/moments.clj
@@ -3,10 +3,10 @@
    [clojure.string :as str]
    [game.core.barrier :refer [update-card-barrier]]
    [game.core.board :refer [hubworld-all-installed]]
-   [game.core.breaching :refer [access-bonus discover-card]]
+   [game.core.breaching :refer [access-bonus discover-card discover-n-cards]]
    [game.core.card :refer [get-card
                            source? seeker? obstacle? moment?
-                           was-in-hand? in-hand? in-deck? was-in-deck? rezzed? installed?]]
+                           in-hand? in-deck? rezzed? installed?]]
    [game.core.def-helpers :refer [defcard stage-n-cards]]
    [game.core.drawing :refer [draw]]
    [game.core.eid :refer [effect-completed]]
@@ -142,8 +142,8 @@
   {:reaction [{:location :hand
                :reaction :pre-discover
                :req (req (and (= side (:engaged-side context))
-                              (or (was-in-hand? (:card context))
-                                  (was-in-deck? (:card context)))
+                              (or (in-hand? (:card context))
+                                  (in-deck? (:card context)))
                               (moment? (:card context))))
                :type :moment
                :prompt (msg "Archive " (:title (:card context)) " and draw 1 card?")
@@ -197,7 +197,7 @@
                               (= (:delver context) side)))
                :ability {:cost [(->c :exile-reaction)]
                          :async true
-                         :effect (req (discover-card state side eid (first (shuffle (get-in @state [opponent :hand])))))}}]})
+                         :effect (req (discover-n-cards state side eid :council 1))}}]})
 
 (defcard "Print on Demand"
   {:on-play {:action true

--- a/src/clj/game/cards/sources.clj
+++ b/src/clj/game/cards/sources.clj
@@ -205,9 +205,16 @@
                            :choices {:req (req (and (my-card? target)
                                                     (in-discard? target)))
                                      :all true}
-                           :msg "shuffles 1 card from [their] Archives into [their] Commons"
+                           :msg "shuffle 1 card from [their] Archives into [their] Commons"
+                           :async true
                            :effect (req (move state side target :deck)
-                                        (shuffle! state side :deck))}}]}))
+                                        (shuffle! state side :deck)
+                                        (continue-ability
+                                          state side
+                                          {:msg "draw 1 card"
+                                           :async true
+                                           :effect (req (draw state side eid 1))}
+                                          card nil))}}]}))
 
 (defcard "Echopomp Revoker"
   (collect
@@ -317,8 +324,7 @@
    :reaction [{:reaction :complete-breach
                :prompt "Gain 2 [Credits]?"
                :type :ability
-               :req (req (and (= (:breach-server context) :commons)
-                              (= (:delver context) side)))
+               :req (req (= (:delver context) side))
                :ability {:cost [(->c :exhaust-self)]
                          :msg "gain 2 [Credits]"
                          :async true

--- a/src/clj/game/core/bluffs.clj
+++ b/src/clj/game/core/bluffs.clj
@@ -3,8 +3,7 @@
    [clojure.string :as str]
    [game.core.card :refer [get-card
                            obstacle? moment?
-                           in-hand? in-deck? rezzed? installed?
-                           was-in-hand? was-in-deck?]]
+                           in-hand? in-deck? rezzed? installed?]]
    [game.core.payment :refer [->c can-pay?]]
    [game.utils :refer [to-keyword  same-card?]]
    [game.macros :refer [continue-ability effect msg req wait-for]]
@@ -65,9 +64,9 @@
                            (bluffs-enabled? state)
                            (or
                              (and ;; KNOT TODAY
-                               (not= side (:engaged-side context))
-                               (or (was-in-hand? (:card context))
-                                   (was-in-deck? (:card context)))
+                               (= side (:engaged-side context))
+                               (or (in-hand? (:card context))
+                                   (in-deck? (:card context)))
                                (moment? (:card context))
                                (< (known-copies state side "Knot Today") 2))
                              (and ;; TENACITY

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -785,7 +785,7 @@
 (defmethod value :steal-heat [cost] (:cost/amount cost))
 (defmethod label :steal-heat [cost] (str "steal " (value cost) " [heat]"))
 (defmethod payable? :steal-heat [cost state side eid card]
-  (>= (value cost) (get-in @state [(other-side side) :heat :base] 0)))
+  (<= (value cost) (get-in @state [(other-side side) :heat :base] 0)))
 (defmethod handler :steal-heat
   [cost state side eid card]
   (wait-for (lose-heat state (other-side side) (value cost) {:suppress-checkpoint true})

--- a/test/clj/game/cards/sources_tests.clj
+++ b/test/clj/game/cards/sources_tests.clj
@@ -185,7 +185,9 @@
     (click-credit state :runner)
     (forge state :corp (pick-card state :corp :council :inner))
     (delve-empty-server state :corp :council)
-    (click-prompts state :corp "Echofield Registry" "Yes" "Shardwinner")))
+    (is (changed? [(count (:hand (get-corp))) 1]
+          (click-prompts state :corp "Echofield Registry" "Yes" "Shardwinner"))
+        "Drew 1")))
 
 (deftest echopomp-revoker-test
   (collects? {:name "Echopomp Revoker"
@@ -302,17 +304,18 @@
         "+1 presence")))
 
 (deftest wall-wizard-test
-  (do-game
-    (new-game {:corp {:hand ["Wall Wizard"]}
-               :runner {:hand [(qty "Fun Run" 5)]}})
-    (play-from-hand state :corp "Wall Wizard" :council :inner)
-    (forge state :corp (pick-card state :corp :council :inner))
-    (click-credit state :runner)
-    (delve-empty-server state :corp :commons)
-    (is (changed? [(:credit (get-corp)) 2]
-          (click-prompts state :corp "Wall Wizard" "Yes"))
-        "Gained 2c")
-    (is (no-prompt? state :corp))))
+  (doseq [s [:commons :archives]]
+    (do-game
+      (new-game {:corp {:hand ["Wall Wizard"]}
+                 :runner {:hand [(qty "Fun Run" 5)]}})
+      (play-from-hand state :corp "Wall Wizard" :council :inner)
+      (forge state :corp (pick-card state :corp :council :inner))
+      (click-credit state :runner)
+      (delve-empty-server state :corp s)
+      (is (changed? [(:credit (get-corp)) 2]
+            (click-prompts state :corp "Wall Wizard" "Yes"))
+          "Gained 2c")
+      (is (no-prompt? state :corp)))))
 
 (deftest waterfront-soakhouse
   (collects? {:name "Waterfront Soakhouse"


### PR DESCRIPTION
This should hit all three of the bugs described here:

1. The sign was backwards on the `payable?` function for stealing heat. Whoops.
2. Wall wizard should now work on any breach. Whoops.
3. Echofield will now draw a card too.

Closes #69

4. Infiltrate now discovers 1 card, so you can adjust the amount of cards you discover with Infiltrate
5. Cards are no longer set aside until post-discovery

Closes #64