### PR TITLE
fix guildmaster yanos

### DIFF
--- a/src/clj/game/cards/agents.clj
+++ b/src/clj/game/cards/agents.clj
@@ -336,6 +336,7 @@
                          :req (req (and (not (same-card? card target))
                                         (not (seeker? target))
                                         (installed? target)
+                                        (my-card? card)
                                         (my-card? target)))}]}))
 
 (defcard "Ulin Marr: Eccentric Architect"

--- a/src/clj/game/cards/agents.clj
+++ b/src/clj/game/cards/agents.clj
@@ -182,7 +182,8 @@
      :static-abilities [{:type :rez-cost
                          :req (req (and (installed? target)
                                         (my-card? target)
-                                        (not (same-card? card target))))
+                                        (not (same-card? card target))
+                                        (my-card? card)))
                          :value -1}]}))
 
 (defcard "Kryzar the Rat: Navigator of the Cortex Maze"

--- a/src/clj/game/cards/sources.clj
+++ b/src/clj/game/cards/sources.clj
@@ -232,6 +232,7 @@
      :static-abilities [{:type :rez-cost
                          :req (req (and (installed? target)
                                         (my-card? target)
+                                        (my-card? card)
                                         (adjacent? card target)))
                          :value -1}]}))
 
@@ -317,7 +318,9 @@
     {:shards 1}
     {:static-abilities [{:type :presence-value
                          :value 1
-                         :req (req (adjacent? card target))}]}))
+                         :req (req (and (my-card? card)
+                                        (my-card? target)
+                                        (adjacent? card target)))}]}))
 
 (defcard "Wall Wizard"
   {:refund 1

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -418,6 +418,8 @@
   "Moves a card to the players :scored area, triggering events from the completion of the steal."
   [state side eid card]
   (let [c (move state side (dissoc card :advance-counter :new :exhausted :installed :rezzed) :scored {:force true})
+        _ (unregister-events state side card)
+        _ (unregister-static-abilities state side card)
         _ (when (card-flag? c :has-events-when-secured true)
             (register-default-events state side c)
             (register-static-abilities state side c))

--- a/test/clj/game/cards/agents_tests.clj
+++ b/test/clj/game/cards/agents_tests.clj
@@ -165,6 +165,27 @@
           (forge state :corp (pick-card state :corp :council :outer)))
         "1c discount")))
 
+(deftest guildmaster-yanos-aura-quirks
+  (do-game
+    (new-game {:corp {:hand ["Guildmaster Yanos: Affable Gaffer" "Barbican Gate"]}
+               :runner {:hand ["Barbican Gate"] :credits 10}})
+    (play-from-hand state :corp "Guildmaster Yanos: Affable Gaffer" :council :outer)
+    (play-from-hand state :runner "Barbican Gate" :council :outer)
+    (play-from-hand state :corp "Barbican Gate" :commons :outer)
+    (forge state :corp (pick-card state :corp :council :outer))
+    (is (changed? [(:credit (get-runner)) -1]
+          (forge state :runner (pick-card state :runner :council :outer)))
+        "Spent 1")
+    (is (= 9 (:credit (get-runner))) "9 credits")
+    (delve-server state :runner :council)
+    (delve-continue-impl state :runner)
+    (click-prompt state :runner "Yes")
+    (click-prompt state :runner "Pay 1 [Credits] and exhaust 1 card protecting your Council: Secure")
+    (click-card state :runner (pick-card state :runner :council :outer))
+    (is (changed? [(:credit (get-corp)) -1]
+          (forge state :corp (pick-card state :corp :commons :outer)))
+        "Spent 1")))
+
 ;; (deftest kryzar-free-stage
 ;;   (do-game
 ;;     (new-game {:corp {:hand ["Kryzar the Rat: Navigator of the Cortex Maze"


### PR DESCRIPTION
Auras now correctly go away when an agent is secured.

I also fixed a few more auras, and made them so they only apply to the source side.